### PR TITLE
Show related substances

### DIFF
--- a/components/IntlProvider/messages.js
+++ b/components/IntlProvider/messages.js
@@ -16,6 +16,7 @@ const messages = {
     'Substance.duration': 'Duration',
     'Substance.summary': 'Summary',
     'Substance.effects': 'Effects',
+    'Substance.related': 'Related substances',
     'Substance.addictionPotential': 'Addiction potential',
     'Substance.toxicity': 'Toxicity',
     'Substance.tolerance': 'Tolerance',

--- a/components/IntlProvider/messages.js
+++ b/components/IntlProvider/messages.js
@@ -24,6 +24,9 @@ const messages = {
     'Substance.tolerance.zero': 'Ideally {zero}',
     'Substance.tolerance.half': 'At least {half}',
     'Substance.tolerance.full': 'Full tolerance',
+    'Substance.allRelatedSubstances': 'All',
+    'Substance.relatedByChemicalClass': 'By chemical class',
+    'Substance.relatedByPsychoactiveClass': 'By psychoactive class',
     'Substance.meta.title':
       '{name} · effects, duration, dosage, toxicity and tolerance · tripby.org',
     'Substance.meta.description': '{name} ({class})',

--- a/components/Substance/Card/index.js
+++ b/components/Substance/Card/index.js
@@ -15,11 +15,29 @@ const SubstanceCard = ({ substance }) => {
           <Heading fontSize={2} fontWeight="500">
             {substance.name}
           </Heading>
-          {substance.class && Array.isArray(substance.class.psychoactive) && (
-            <Text mt={2} color={colors.persianGreen}>
-              {substance.class.psychoactive.join(' / ')}
-            </Text>
-          )}
+          {(() => {
+            if (substance.class) {
+              if (
+                Array.isArray(substance.class.psychoactive) &&
+                substance.class.psychoactive.length > 0
+              ) {
+                return (
+                  <Text mt={2} color={colors.persianGreen}>
+                    {substance.class.psychoactive.join(' / ')}
+                  </Text>
+                );
+              } else if (
+                Array.isArray(substance.class.chemical) &&
+                substance.class.chemical.length > 0
+              ) {
+                return (
+                  <Text mt={2} color={colors.persianGreen}>
+                    {substance.class.chemical.join(' / ')}
+                  </Text>
+                );
+              }
+            }
+          })()}
         </Card>
       </a>
     </Link>

--- a/components/Substance/Content/index.js
+++ b/components/Substance/Content/index.js
@@ -10,6 +10,7 @@ import Card from '../../Card';
 import { FormattedMessage } from 'react-intl';
 import Heading from '../../Heading';
 import SubstanceEffects from '../Effects';
+import SubstanceRelated from '../Related';
 
 const tabs = [
   {
@@ -23,6 +24,12 @@ const tabs = [
     content: ({ substance }) => (
       <SubstanceEffects effects={substance.effects} />
     ),
+  },
+  {
+    id: 'related',
+    label: 'Substance.related',
+    content: ({ substance }) => <SubstanceRelated substance={substance} />,
+    alwaysShow: true,
   },
 ];
 
@@ -50,7 +57,9 @@ const StyledTab = styled(Tab).attrs(() => ({ fontSize: 2 }))`
 `;
 
 const SubstanceContent = ({ substance }) => {
-  const contentfulTabs = tabs.filter(tab => substance[tab.id]);
+  const contentfulTabs = tabs.filter(
+    tab => substance[tab.id] || tab.alwaysShow
+  );
   const { query, push, pathname } = useRouter();
   const selectedTabIndex = query.tab
     ? contentfulTabs.findIndex(tab => tab.id === query.tab)

--- a/components/Substance/Content/index.js
+++ b/components/Substance/Content/index.js
@@ -11,6 +11,7 @@ import { FormattedMessage } from 'react-intl';
 import Heading from '../../Heading';
 import SubstanceEffects from '../Effects';
 import SubstanceRelated from '../Related';
+import { StyledTabList, StyledTab } from '../../Tabs';
 
 const tabs = [
   {
@@ -33,28 +34,14 @@ const tabs = [
   },
 ];
 
-const StyledTabList = styled(TabList)`
-  ${space}
-  display: flex;
-  align-items: center;
+const BorderedTabList = styled(StyledTabList)`
   border-bottom: ${({ theme }) => theme.border};
 `;
 
-StyledTabList.defaultProps = {
+BorderedTabList.defaultProps = {
   variant: 'primary',
+  fontSize: 2,
 };
-
-const StyledTab = styled(Tab).attrs(() => ({ fontSize: 2 }))`
-  ${space}
-  ${fontSize}
-  cursor: pointer;
-  transition: 0.2s;
-  color: ${({ theme }) => theme.textColor({ theme, variant: 'secondary' })};
-  &.react-tabs__tab--selected,
-  &:hover {
-    color: ${({ theme }) => theme.colors.purpleHeart};
-  }
-`;
 
 const SubstanceContent = ({ substance }) => {
   const contentfulTabs = tabs.filter(
@@ -75,7 +62,7 @@ const SubstanceContent = ({ substance }) => {
   return (
     <Card shadow={false} p={0} style={{ overflow: 'hidden' }}>
       <Tabs defaultIndex={selectedTabIndex} onSelect={onSelectTab}>
-        <StyledTabList mx={-2} p={3}>
+        <BorderedTabList mx={-2} p={3}>
           {contentfulTabs.map(tab => {
             return (
               <StyledTab px={2} key={tab.id}>
@@ -83,7 +70,7 @@ const SubstanceContent = ({ substance }) => {
               </StyledTab>
             );
           })}
-        </StyledTabList>
+        </BorderedTabList>
         <Box p={3}>
           {contentfulTabs.map(tab => (
             <TabPanel key={`tab-${tab.id}-content`}>

--- a/components/Substance/Related/index.js
+++ b/components/Substance/Related/index.js
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types';
 import { useQuery } from 'react-apollo-hooks';
 import { Flex, Box } from 'rebass';
 import uniqBy from 'lodash/uniqBy';
+import { Tabs, TabPanel } from 'react-tabs';
+import { StyledTabList, StyledTab } from '../../Tabs';
 import GET_SUBSTANCES from '../../../queries/substances';
 import SubstanceCard from '../Card';
+import { FormattedMessage } from 'react-intl';
 
 const SubstanceRelated = ({ substance }) => {
   const { data } = useQuery(GET_SUBSTANCES, { variables: { limit: 300 } });
@@ -25,21 +28,51 @@ const SubstanceRelated = ({ substance }) => {
           substance.class.psychoactive.includes(psychoactiveClass)
         )
     );
-    const relatedSubstances = uniqBy(
-      [
-        ...relatedSubstancesByChemicalClass,
-        ...relatedSubstancesByPsychoactiveClass,
-      ],
-      'name'
-    );
+    const relatedSubstances = [
+      {
+        id: 'Substance.allRelatedSubstances',
+        value: uniqBy(
+          [
+            ...relatedSubstancesByChemicalClass,
+            ...relatedSubstancesByPsychoactiveClass,
+          ],
+          'name'
+        ),
+      },
+      {
+        id: 'Substance.relatedByChemicalClass',
+        value: relatedSubstancesByChemicalClass,
+      },
+      {
+        id: 'Substance.relatedByPsychoactiveClass',
+        value: relatedSubstancesByPsychoactiveClass,
+      },
+    ];
     return (
-      <Flex flexWrap="wrap" m={-1}>
-        {relatedSubstances.map(relatedSubstance => (
-          <Box p={1} key={relatedSubstance.name} width={[1, 1 / 2, 1 / 3]}>
-            <SubstanceCard substance={relatedSubstance} />
-          </Box>
+      <Tabs>
+        <StyledTabList m={-1} pb={3}>
+          {relatedSubstances.map(cat => (
+            <StyledTab p={1} key={`${cat.id}-tab`}>
+              <FormattedMessage id={cat.id} />
+            </StyledTab>
+          ))}
+        </StyledTabList>
+        {relatedSubstances.map(cat => (
+          <TabPanel key={`${cat.id}-content`}>
+            <Flex flexWrap="wrap" m={-1}>
+              {cat.value.map(relatedSubstance => (
+                <Box
+                  p={1}
+                  key={relatedSubstance.name}
+                  width={[1, 1 / 2, 1 / 3]}
+                >
+                  <SubstanceCard substance={relatedSubstance} />
+                </Box>
+              ))}
+            </Flex>
+          </TabPanel>
         ))}
-      </Flex>
+      </Tabs>
     );
   }
   return null;

--- a/components/Substance/Related/index.js
+++ b/components/Substance/Related/index.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useQuery } from 'react-apollo-hooks';
+import { Flex, Box } from 'rebass';
+import uniqBy from 'lodash/uniqBy';
+import GET_SUBSTANCES from '../../../queries/substances';
+import SubstanceCard from '../Card';
+
+const SubstanceRelated = ({ substance }) => {
+  const { data } = useQuery(GET_SUBSTANCES, { variables: { limit: 300 } });
+  if (data && data.substances) {
+    const relatedSubstancesByChemicalClass = data.substances.filter(
+      _substance =>
+        _substance.class &&
+        _substance.class.chemical &&
+        _substance.class.chemical.some(chemicalClass =>
+          substance.class.chemical.includes(chemicalClass)
+        )
+    );
+    const relatedSubstancesByPsychoactiveClass = data.substances.filter(
+      _substance =>
+        _substance.class &&
+        _substance.class.psychoactive &&
+        _substance.class.psychoactive.some(psychoactiveClass =>
+          substance.class.psychoactive.includes(psychoactiveClass)
+        )
+    );
+    const relatedSubstances = uniqBy(
+      [
+        ...relatedSubstancesByChemicalClass,
+        ...relatedSubstancesByPsychoactiveClass,
+      ],
+      'name'
+    );
+    return (
+      <Flex flexWrap="wrap" m={-1}>
+        {relatedSubstances.map(relatedSubstance => (
+          <Box p={1} key={relatedSubstance.name} width={[1, 1 / 2, 1 / 3]}>
+            <SubstanceCard substance={relatedSubstance} />
+          </Box>
+        ))}
+      </Flex>
+    );
+  }
+  return null;
+};
+
+SubstanceRelated.propTypes = {};
+
+export default SubstanceRelated;

--- a/components/Tabs/index.js
+++ b/components/Tabs/index.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import { TabList, Tab } from 'react-tabs';
+import { space, fontSize } from 'styled-system';
+
+export const StyledTabList = styled(TabList)`
+  ${space}
+  ${fontSize}
+  display: flex;
+  align-items: center;
+`;
+
+StyledTabList.defaultProps = {
+  variant: 'primary',
+};
+
+export const StyledTab = styled(Tab)`
+  ${space}
+  ${fontSize}
+  cursor: pointer;
+  transition: 0.2s;
+  color: ${({ theme }) => theme.textColor({ theme, variant: 'secondary' })};
+  &.react-tabs__tab--selected,
+  &:hover {
+    color: ${({ theme }) => theme.colors.purpleHeart};
+  }
+`;


### PR DESCRIPTION
Introduces a "Related substances" tab on the content card of each substance.

It gets related substances by:
- psychoactive class
- chemical class
- both

# demo
![image](https://user-images.githubusercontent.com/16964673/58747299-7cb24080-8469-11e9-9f5c-ff6c84eb38e8.png)
