### PR TITLE
Use friendlier URLs for substances

### DIFF
--- a/components/Substance/Card/index.js
+++ b/components/Substance/Card/index.js
@@ -5,11 +5,17 @@ import Link from 'next/link';
 import Card from '../../Card';
 import Heading from '../../Heading';
 import Text from '../../Text';
-import { colors } from '../../../lib/constants';
+import { colors, NODE_ENV } from '../../../lib/constants';
 
 const SubstanceCard = ({ substance }) => {
   return (
-    <Link href={`substance?name=${substance.name}`}>
+    <Link
+      href={
+        NODE_ENV === 'production'
+          ? `substance/${substance.name}`
+          : `substance?name=${substance.name}`
+      }
+    >
       <a>
         <Card style={{ overflow: 'auto' }}>
           <Heading fontSize={2} fontWeight="500">

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,5 +1,7 @@
 export const WIKI_API_URL = 'https://api.psychonautwiki.org/';
 
+export const NODE_ENV = process.env.NODE_ENV;
+
 export const GA_TRACKING_ID = 'UA-61977009-1';
 
 export const defaultLocale = 'en';

--- a/now.json
+++ b/now.json
@@ -4,6 +4,7 @@
   "regions": ["gru1", "cdg1", "sfo1"],
   "alias": "tripby.org",
   "routes": [
+    { "src": "/substance/(?<name>[^/]+)", "dest": "/substance?name=$name" },
     {
       "src": "/sitemap.xml",
       "dest": "https://tripby-sitemap-generator.herokuapp.com/"


### PR DESCRIPTION
Adds support to the following URL format: `/substance/<name>`

Still maintains the original format on development, since it's not yet supported by `next.js`