### PR TITLE
Handle cases where substance has null properties

### DIFF
--- a/components/Substance/Content/index.js
+++ b/components/Substance/Content/index.js
@@ -17,19 +17,24 @@ const tabs = [
   {
     id: 'summary',
     label: 'Substance.summary',
-    content: ({ substance }) => substance.summary,
+    content: ({ substance }) => substance.summary || null,
   },
   {
     id: 'effects',
     label: 'Substance.effects',
-    content: ({ substance }) => (
-      <SubstanceEffects effects={substance.effects} />
-    ),
+    content: ({ substance }) =>
+      substance.effects ? (
+        <SubstanceEffects effects={substance.effects} />
+      ) : null,
   },
   {
     id: 'related',
     label: 'Substance.related',
-    content: ({ substance }) => <SubstanceRelated substance={substance} />,
+    content: ({ substance }) =>
+      substance.class &&
+      (substance.class.psychoactive || substance.class.chemical) ? (
+        <SubstanceRelated substance={substance} />
+      ) : null,
     alwaysShow: true,
   },
 ];
@@ -45,7 +50,7 @@ BorderedTabList.defaultProps = {
 
 const SubstanceContent = ({ substance }) => {
   const contentfulTabs = tabs.filter(
-    tab => substance[tab.id] || tab.alwaysShow
+    tab => tab.content({ substance }) !== null
   );
   const { query, push, pathname } = useRouter();
   const selectedTabIndex = query.tab

--- a/components/Substance/Related/index.js
+++ b/components/Substance/Related/index.js
@@ -12,9 +12,12 @@ import { FormattedMessage } from 'react-intl';
 const SubstanceRelated = ({ substance }) => {
   const { data } = useQuery(GET_SUBSTANCES, { variables: { limit: 300 } });
   if (data && data.substances) {
+    const otherSubstances = data.substances.filter(
+      sub => sub.name !== substance.name
+    );
     const relatedSubstancesByChemicalClass =
       substance.class && substance.class.chemical
-        ? data.substances.filter(
+        ? otherSubstances.filter(
             _substance =>
               _substance.class &&
               _substance.class.chemical &&
@@ -25,7 +28,7 @@ const SubstanceRelated = ({ substance }) => {
         : [];
     const relatedSubstancesByPsychoactiveClass =
       substance.class && substance.class.psychoactive
-        ? data.substances.filter(
+        ? otherSubstances.filter(
             _substance =>
               _substance.class &&
               _substance.class.psychoactive &&
@@ -54,16 +57,19 @@ const SubstanceRelated = ({ substance }) => {
         value: relatedSubstancesByPsychoactiveClass,
       },
     ];
+    const contentfulRelatedSubstances = relatedSubstances.filter(
+      cat => cat.value.length > 0
+    );
     return (
       <Tabs>
         <StyledTabList m={-1} pb={3}>
-          {relatedSubstances.map(cat => (
+          {contentfulRelatedSubstances.map(cat => (
             <StyledTab p={1} key={`${cat.id}-tab`}>
               <FormattedMessage id={cat.id} />
             </StyledTab>
           ))}
         </StyledTabList>
-        {relatedSubstances.map(cat => (
+        {contentfulRelatedSubstances.map(cat => (
           <TabPanel key={`${cat.id}-content`}>
             <Flex flexWrap="wrap" m={-1}>
               {cat.value.map(relatedSubstance => (

--- a/components/Substance/Related/index.js
+++ b/components/Substance/Related/index.js
@@ -12,22 +12,28 @@ import { FormattedMessage } from 'react-intl';
 const SubstanceRelated = ({ substance }) => {
   const { data } = useQuery(GET_SUBSTANCES, { variables: { limit: 300 } });
   if (data && data.substances) {
-    const relatedSubstancesByChemicalClass = data.substances.filter(
-      _substance =>
-        _substance.class &&
-        _substance.class.chemical &&
-        _substance.class.chemical.some(chemicalClass =>
-          substance.class.chemical.includes(chemicalClass)
-        )
-    );
-    const relatedSubstancesByPsychoactiveClass = data.substances.filter(
-      _substance =>
-        _substance.class &&
-        _substance.class.psychoactive &&
-        _substance.class.psychoactive.some(psychoactiveClass =>
-          substance.class.psychoactive.includes(psychoactiveClass)
-        )
-    );
+    const relatedSubstancesByChemicalClass =
+      substance.class && substance.class.chemical
+        ? data.substances.filter(
+            _substance =>
+              _substance.class &&
+              _substance.class.chemical &&
+              _substance.class.chemical.some(chemicalClass =>
+                substance.class.chemical.includes(chemicalClass)
+              )
+          )
+        : [];
+    const relatedSubstancesByPsychoactiveClass =
+      substance.class && substance.class.psychoactive
+        ? data.substances.filter(
+            _substance =>
+              _substance.class &&
+              _substance.class.psychoactive &&
+              _substance.class.psychoactive.some(psychoactiveClass =>
+                substance.class.psychoactive.includes(psychoactiveClass)
+              )
+          )
+        : [];
     const relatedSubstances = [
       {
         id: 'Substance.allRelatedSubstances',


### PR DESCRIPTION
- Complements #62 by making checks for whether the substance has non null chemical/psychoactive class so they can be used to filter related substances.
- Remove substance from its own related subatances listing
- Updates the condition on whether the content tabs must be rendered, depending on if they have content or not.