### PR TITLE
Replace Array.flatMap() with lodash's flatMap

### DIFF
--- a/components/Home/index.js
+++ b/components/Home/index.js
@@ -12,7 +12,7 @@ import Text from '../Text';
 import ApolloError from '../ApolloError';
 
 const getClasses = (list, type) => {
-  return [...new Set(list?.flatMap(substance => substance?.class?.[type]))]
+  return [...new Set(list?.map(substance => substance?.class?.[type]).flat())]
     .filter(Boolean)
     .sort((a, b) => a > b);
 };

--- a/components/Home/index.js
+++ b/components/Home/index.js
@@ -12,7 +12,7 @@ import Text from '../Text';
 import ApolloError from '../ApolloError';
 
 const getClasses = (list, type) => {
-  return [...new Set(list.flatMap(substance => substance?.class?.[type]))]
+  return [...new Set(list?.flatMap(substance => substance?.class?.[type]))]
     .filter(Boolean)
     .sort((a, b) => a > b);
 };
@@ -52,7 +52,7 @@ const Home = () => {
     [filter]
   );
   const substanceList =
-    data && data.substances
+    data && data.substances && Array.isArray(data.substances)
       ? sortSubstances(filterSubstances(data?.substances))
       : [];
   const noResults = filter.length > 0 && substanceList.length === 0;

--- a/components/Home/index.js
+++ b/components/Home/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { useQuery } from 'react-apollo-hooks';
 import { Box, Flex } from 'rebass';
+import flatMap from 'lodash/flatMap';
 
 import GET_SUBSTANCES from '../../queries/substances';
 import Input from '../Input';
@@ -12,7 +13,7 @@ import Text from '../Text';
 import ApolloError from '../ApolloError';
 
 const getClasses = (list, type) => {
-  return [...new Set(list?.map(substance => substance?.class?.[type]).flat())]
+  return [...new Set(flatMap(list, substance => substance?.class?.[type]))]
     .filter(Boolean)
     .sort((a, b) => a > b);
 };


### PR DESCRIPTION
`Array.flatMap()` is not supported on the server, so we're getting 500 errors:

```
2019-09-22T08:46:55.025Z	d8223dd7-bcf0-4c0a-a9ba-84257d97e845	Error while running `getDataFromTree` TypeError: list.flatMap is not a function
    at getClasses (/var/task/page.js:36243:70)
    at Home (/var/task/page.js:36288:29)
    at c (/var/task/page.js:16757:501)
    at Sa (/var/task/page.js:16760:1)
    at a.module.exports.FDah.a.render (/var/task/page.js:16765:467)
    at a.module.exports.FDah.a.read (/var/task/page.js:16765:58)
    at renderToStaticMarkup (/var/task/page.js:16777:181)
    at process (/var/task/page.js:45619:20)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
```

![image](https://user-images.githubusercontent.com/16964673/65384893-6be74c80-dd30-11e9-9f54-fffa763f6c7e.png)

This PR replaces it with lodash's `flatMap()`