### PR TITLE
fix(substance/page): pass correct error object to <ApolloError />

### DIFF
--- a/components/Substance/Page/index.js
+++ b/components/Substance/Page/index.js
@@ -41,7 +41,7 @@ const SubstancePage = () => {
   if (error) {
     return (
       <Container>
-        <ApolloError error={data.error} />
+        <ApolloError error={error} />
       </Container>
     );
   }


### PR DESCRIPTION
closes #88

`<ApolloError/>` was not receiving the correct error payload in substance pages, leading the app to crash when such errors occur: (see #88)

<img src="https://user-images.githubusercontent.com/16964673/90261883-f5f64300-de23-11ea-859b-e4ed08e98e3d.png" width="480" />


# Fix preview

![image](https://user-images.githubusercontent.com/16964673/90261786-d52ded80-de23-11ea-8761-689454994425.png)
